### PR TITLE
Add namespaces for AGP 8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.caincamera'
 
     defaultConfig {
         applicationId "com.cgfay.caincamera"

--- a/cameralibrary/build.gradle
+++ b/cameralibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.cameralibrary'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/facedetectlibrary/build.gradle
+++ b/facedetectlibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.facedetectlibrary'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/filterlibrary/build.gradle
+++ b/filterlibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.filterlibrary'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/gdxlibrary/build.gradle
+++ b/gdxlibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.badlogic.gdx'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/imagelibrary/build.gradle
+++ b/imagelibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.imagelibrary'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/landmarklibrary/build.gradle
+++ b/landmarklibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.landmarklibrary'
 
 
     defaultConfig {

--- a/medialibrary/build.gradle
+++ b/medialibrary/build.gradle
@@ -7,6 +7,7 @@ def platformVersion = rootProject.ext.minSdkVersion    // 18: openGLES 3 min api
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.media'
 
     defaultConfig {
         minSdkVersion "${platformVersion}"

--- a/pickerlibrary/build.gradle
+++ b/pickerlibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.scan'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/utilslibrary/build.gradle
+++ b/utilslibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.utilslibrary'
 
 
     defaultConfig {

--- a/videolibrary/build.gradle
+++ b/videolibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.video'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/widgetlibrary/build.gradle
+++ b/widgetlibrary/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+    namespace 'com.cgfay.design'
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
## Summary
- specify `namespace` in every Android module's `build.gradle`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a896fd58832c991aee4dea161d21