### PR TITLE
Fix widget library imports

### DIFF
--- a/widgetlibrary/src/main/java/com/cgfay/widget/CameraTabView.java
+++ b/widgetlibrary/src/main/java/com/cgfay/widget/CameraTabView.java
@@ -55,7 +55,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.cgfay.design.R;
+import com.google.android.material.R;
 import com.cgfay.resources.MaterialResources;
 import com.cgfay.internal.ViewUtils;
 

--- a/widgetlibrary/src/main/java/com/cgfay/widget/TabItem.java
+++ b/widgetlibrary/src/main/java/com/cgfay/widget/TabItem.java
@@ -6,7 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
 
-import com.cgfay.design.R;
+import com.google.android.material.R;
 
 
 /**

--- a/widgetlibrary/src/main/java/com/cgfay/widget/ThemeUtils.java
+++ b/widgetlibrary/src/main/java/com/cgfay/widget/ThemeUtils.java
@@ -3,7 +3,7 @@ package com.cgfay.widget;
 import android.content.Context;
 import android.content.res.TypedArray;
 
-import com.cgfay.design.R;
+import androidx.appcompat.R;
 
 /**
  * @author CainHuang


### PR DESCRIPTION
## Summary
- fix imports in widget library to use Material/AppCompat resources

## Testing
- `./gradlew :widgetlibrary:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c80b8610832cab8f810d4aaa0309