### PR TITLE
Fix lifecycle version in gradle config

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -13,7 +13,7 @@ ext {
     junitVersion = '4.13.2'
     androidXJunitVersion = '1.2.1'
     espressoVersion = '3.6.1'
-    lifecycleVersion = '2.9.2'
+    lifecycleVersion = '2.2.0'
     cameraXVersion = '1.4.2'
     rxJavaVersion = '2.2.21'
     rxAndroidVersion = '2.1.1'


### PR DESCRIPTION
## Summary
- fix `lifecycle-extensions` dependency resolution by using latest available version 2.2.0

## Testing
- `./gradlew :app:assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c87c023c832c91b4f3ba7d367020