### PR TITLE
Fix picker library resource references

### DIFF
--- a/pickerlibrary/src/main/java/com/cgfay/picker/adapter/AlbumDataAdapter.java
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/adapter/AlbumDataAdapter.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import com.cgfay.picker.MediaPickerManager;
 import com.cgfay.scan.R;
+
 import com.cgfay.picker.model.AlbumData;
 
 import java.util.ArrayList;
@@ -44,7 +45,9 @@ public class AlbumDataAdapter extends RecyclerView.Adapter<AlbumDataAdapter.Albu
         holder.mAlbumMediaCount.setText(String.valueOf(album.getCount()));
         MediaPickerManager.getInstance().getMediaLoader()
                 .loadThumbnail(holder.itemView.getContext(), holder.mAlbumThumbnail,
-                        album.getCoverUri(), R.color.black, R.color.black);
+                        album.getCoverUri(),
+                        com.cgfay.utilslibrary.R.color.black,
+                        com.cgfay.utilslibrary.R.color.black);
         holder.itemView.setOnClickListener(v -> {
             if (mAlbumSelectedListener != null) {
                 mAlbumSelectedListener.onAlbumSelected(album);

--- a/pickerlibrary/src/main/java/com/cgfay/picker/adapter/MediaDataAdapter.java
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/adapter/MediaDataAdapter.java
@@ -60,12 +60,14 @@ public class MediaDataAdapter extends RecyclerView.Adapter<MediaDataAdapter.Thum
                 MediaPickerManager.getInstance().getMediaLoader()
                         .loadThumbnail(holder.itemView.getContext(),
                         holder.mThumbnailView, mediaData.getContentUri(), mResize,
-                        R.color.white, R.color.white);
+                        com.cgfay.utilslibrary.R.color.white,
+                        com.cgfay.utilslibrary.R.color.white);
             } else {
                 MediaPickerManager.getInstance().getMediaLoader()
                         .loadThumbnail(holder.itemView.getContext(),
                         holder.mThumbnailView, mediaData.getContentUri(),
-                        R.color.white, R.color.white);
+                        com.cgfay.utilslibrary.R.color.white,
+                        com.cgfay.utilslibrary.R.color.white);
             }
 
             if (mediaData.isVideo()) {

--- a/pickerlibrary/src/main/java/com/cgfay/picker/fragment/MediaDataFragment.java
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/fragment/MediaDataFragment.java
@@ -241,7 +241,9 @@ public abstract class MediaDataFragment extends Fragment implements IMediaDataRe
      * 指定加载图片的大小
      */
     private void setItemImageSize() {
-        int divSize = (int)(getResources().getDimension(R.dimen.dp4) * (mMediaPickerParam.getSpanCount() + 1));
+        int divSize = (int)(getResources().getDimension(
+                com.cgfay.utilslibrary.R.dimen.dp4) *
+                (mMediaPickerParam.getSpanCount() + 1));
         int imageSize = getResources().getDisplayMetrics().widthPixels - divSize;
         int resize = imageSize / mMediaPickerParam.getSpanCount();
         mMediaDataAdapter.setThumbnailResize(resize);


### PR DESCRIPTION
## Summary
- fix resource access errors in picker library when building with namespaced R

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881cb7ae640832c8c23b3837ffe017b