### PR TITLE
Fix missing resource errors by enabling transitive R

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,8 @@ android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 android.injected.testOnly=false
+# Include resources from dependent modules in generated R classes
+android.nonTransitiveRClass=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Summary
- allow modules to access resources from their dependencies by setting `android.nonTransitiveRClass` to `false`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d87a0a38832cad3722d26abee4be