### PR TITLE
Fix Gradle resource constants

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.injected.testOnly=false
 # Include resources from dependent modules in generated R classes
 android.nonTransitiveRClass=false
+android.nonFinalResIds=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Summary
- ensure generated resource IDs remain final by disabling `nonFinalResIds`

## Testing
- `./gradlew :app:compileDebugJavaWithJavac` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881dc374a00832cbc771e900e91de21