### PR TITLE
Add Jetpack Compose example for widgetlibrary

### DIFF
--- a/widgetlibrary/build.gradle
+++ b/widgetlibrary/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -22,6 +25,18 @@ android {
         }
     }
 
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion rootProject.ext.composeVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -33,6 +48,11 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:${rootProject.ext.appcompatVersion}"
     implementation "com.google.android.material:material:${rootProject.ext.materialVersion}"
+    implementation "androidx.activity:activity-compose:1.9.0"
+    implementation "androidx.compose.ui:ui:${rootProject.ext.composeVersion}"
+    implementation "androidx.compose.material:material:${rootProject.ext.composeVersion}"
+    implementation "androidx.compose.ui:ui-tooling-preview:${rootProject.ext.composeVersion}"
+    debugImplementation "androidx.compose.ui:ui-tooling:${rootProject.ext.composeVersion}"
     testImplementation "junit:junit:${rootProject.ext.junitVersion}"
     androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.androidXJunitVersion}"
     androidTestImplementation "androidx.test.espresso:espresso-core:${rootProject.ext.espressoVersion}"

--- a/widgetlibrary/src/main/java/com/cgfay/widget/compose/CameraTabComposable.kt
+++ b/widgetlibrary/src/main/java/com/cgfay/widget/compose/CameraTabComposable.kt
@@ -1,0 +1,36 @@
+package com.cgfay.widget.compose
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+
+/**
+ * Simple composable replacement for [com.cgfay.widget.CameraTabView].
+ *
+ * @param tabs Labels for each tab.
+ * @param modifier Modifier applied to the TabRow.
+ * @param onTabSelected Callback when a tab is selected.
+ */
+@Composable
+fun CameraTabRow(
+    tabs: List<String>,
+    modifier: Modifier = Modifier,
+    onTabSelected: (index: Int) -> Unit = {}
+) {
+    var selectedTab by remember { mutableStateOf(0) }
+    TabRow(selectedTabIndex = selectedTab, modifier = modifier.fillMaxWidth()) {
+        tabs.forEachIndexed { index, title ->
+            Tab(
+                selected = index == selectedTab,
+                onClick = {
+                    selectedTab = index
+                    onTabSelected(index)
+                },
+                text = { Text(text = title) }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert widgetlibrary module to use Jetpack Compose
- add a simple `CameraTabRow` composable

## Testing
- `./gradlew :widgetlibrary:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e7bf7254832c9a4f9f9fcc5068ea