### PR TITLE
Add Compose album list screen

### DIFF
--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/AlbumListScreen.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/AlbumListScreen.kt
@@ -1,0 +1,64 @@
+package com.cgfay.picker.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.cgfay.picker.model.AlbumData
+import com.cgfay.scan.R
+
+@Composable
+fun AlbumListScreen(onBack: () -> Unit, viewModel: PickerViewModel = viewModel()) {
+    val albums by viewModel.albumList.collectAsState()
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(text = "Albums") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(painterResource(id = R.drawable.ic_media_picker_close), contentDescription = null)
+                }
+            }
+        )
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(albums) { album ->
+                AlbumRow(album = album, onClick = {
+                    viewModel.selectAlbum(album)
+                    onBack()
+                })
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumRow(album: AlbumData, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_media_picker_preview),
+            contentDescription = null,
+            modifier = Modifier.size(56.dp)
+        )
+        Column(modifier = Modifier.padding(start = 12.dp)) {
+            Text(text = album.displayName, style = MaterialTheme.typography.bodyLarge)
+            Text(text = album.count.toString(), style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
@@ -22,22 +22,33 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.cgfay.scan.R
 
 @Composable
-fun MediaPickerScreen(onPreview: (Int) -> Unit, viewModel: PickerViewModel = viewModel()) {
+fun MediaPickerScreen(
+    onPreview: (Int) -> Unit,
+    onShowAlbums: () -> Unit,
+    viewModel: PickerViewModel = viewModel()
+) {
     val mediaList by viewModel.mediaList.collectAsState()
     val selected by viewModel.selectedMedia.collectAsState()
+    val album by viewModel.selectedAlbum.collectAsState()
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text("Media Picker") },
+            title = { Text(album?.displayName ?: "Media Picker") },
             navigationIcon = {
                 IconButton(onClick = { viewModel.finish() }) {
                     Icon(painterResource(R.drawable.ic_media_picker_close), contentDescription = null)
                 }
             },
             actions = {
+                IconButton(onClick = onShowAlbums) {
+                    Icon(painterResource(id = R.drawable.ic_media_album_indicator), contentDescription = null)
+                }
                 if (selected.isNotEmpty()) {
-                    Text(text = "Select(${selected.size})", modifier = Modifier
-                        .padding(end = 8.dp)
-                        .clickable { viewModel.confirmSelection() })
+                    Text(
+                        text = "Select(${selected.size})",
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .clickable { viewModel.confirmSelection() }
+                    )
                 }
             }
         )

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerNav.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerNav.kt
@@ -5,19 +5,28 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 
+/** Import screens */
+import com.cgfay.picker.compose.AlbumListScreen
+
 @Composable
 fun PickerNavHost() {
     val navController = rememberNavController()
     NavHost(navController, startDestination = "picker") {
         composable("picker") {
-            MediaPickerScreen { id ->
-                navController.currentBackStackEntry?.arguments?.putInt("media", id)
-                navController.navigate("preview")
-            }
+            MediaPickerScreen(
+                onPreview = { id ->
+                    navController.currentBackStackEntry?.arguments?.putInt("media", id)
+                    navController.navigate("preview")
+                },
+                onShowAlbums = { navController.navigate("albums") }
+            )
         }
         composable("preview") { backStackEntry ->
             val id = backStackEntry.arguments?.getInt("media")
             MediaPreviewScreen(id) { navController.popBackStack() }
+        }
+        composable("albums") {
+            AlbumListScreen { navController.popBackStack() }
         }
     }
 }

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerViewModel.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerViewModel.kt
@@ -1,9 +1,11 @@
 package com.cgfay.picker.compose
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import com.cgfay.scan.R
+import com.cgfay.picker.model.AlbumData
 
 class PickerViewModel : ViewModel() {
     private val _mediaList = MutableStateFlow<List<Int>>(emptyList())
@@ -12,9 +14,20 @@ class PickerViewModel : ViewModel() {
     private val _selectedMedia = MutableStateFlow<List<Int>>(emptyList())
     val selectedMedia: StateFlow<List<Int>> = _selectedMedia
 
+    private val _albumList = MutableStateFlow<List<AlbumData>>(emptyList())
+    val albumList: StateFlow<List<AlbumData>> = _albumList
+
+    private val _selectedAlbum = MutableStateFlow<AlbumData?>(null)
+    val selectedAlbum: StateFlow<AlbumData?> = _selectedAlbum
+
     init {
         // Compose demo placeholder data using library icons
         _mediaList.value = List(30) { R.drawable.ic_media_picker_preview }
+        _albumList.value = listOf(
+            AlbumData("1", Uri.EMPTY, "All", 30),
+            AlbumData("2", Uri.EMPTY, "Favorites", 15)
+        )
+        _selectedAlbum.value = _albumList.value.firstOrNull()
     }
 
     fun toggle(media: Int) {
@@ -25,6 +38,11 @@ class PickerViewModel : ViewModel() {
 
     fun confirmSelection() {
         // TODO send selection result
+    }
+
+    fun selectAlbum(album: AlbumData) {
+        _selectedAlbum.value = album
+        // TODO load album media
     }
 
     fun finish() {


### PR DESCRIPTION
## Summary
- add AlbumListScreen using LazyColumn
- wire up PickerNav to display album list
- show selected album in MediaPickerScreen
- manage albums in PickerViewModel

## Testing
- `./gradlew :pickerlibrary:test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882229482ac832c9c9b07f0395d8a10