### PR TITLE
Migrate picker compose images to Coil

### DIFF
--- a/pickerlibrary/build.gradle
+++ b/pickerlibrary/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "androidx.compose.material:material:${rootProject.ext.composeVersion}"
     implementation "androidx.compose.ui:ui-tooling-preview:${rootProject.ext.composeVersion}"
     implementation "androidx.navigation:navigation-compose:2.7.7"
+    implementation "io.coil-kt:coil-compose:2.5.0"
     debugImplementation "androidx.compose.ui:ui-tooling:${rootProject.ext.composeVersion}"
     testImplementation "junit:junit:${rootProject.ext.junitVersion}"
     androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.androidXJunitVersion}"

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
@@ -1,6 +1,5 @@
 package com.cgfay.picker.compose
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -20,6 +19,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.cgfay.scan.R
+import coil.compose.AsyncImage
 
 @Composable
 fun MediaPickerScreen(
@@ -57,8 +57,8 @@ fun MediaPickerScreen(
                 Box(modifier = Modifier
                     .padding(2.dp)
                     .clickable { onPreview(media) }, contentAlignment = Alignment.Center) {
-                    Image(
-                        painterResource(id = media),
+                    AsyncImage(
+                        model = media,
                         contentDescription = null,
                         modifier = Modifier.size(100.dp)
                     )


### PR DESCRIPTION
## Summary
- use `AsyncImage` from Coil in the compose media picker grid
- include `coil-compose` dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822431d9a8832c9b8d00c3d896d95b