### PR TITLE
Migrate video editor UI to Compose

### DIFF
--- a/videolibrary/build.gradle
+++ b/videolibrary/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "androidx.compose.material:material:${rootProject.ext.composeVersion}"
     implementation "androidx.compose.ui:ui-tooling-preview:${rootProject.ext.composeVersion}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${rootProject.ext.lifecycleVersion}"
+    implementation "io.coil-kt:coil-compose:2.4.0"
     debugImplementation "androidx.compose.ui:ui-tooling:${rootProject.ext.composeVersion}"
     testImplementation "junit:junit:${rootProject.ext.junitVersion}"
     androidTestImplementation "androidx.test.ext:junit:${rootProject.ext.androidXJunitVersion}"

--- a/videolibrary/src/main/java/com/cgfay/video/compose/EffectListCompose.kt
+++ b/videolibrary/src/main/java/com/cgfay/video/compose/EffectListCompose.kt
@@ -1,0 +1,119 @@
+package com.cgfay.video.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.cgfay.filter.glfilter.resource.bean.ResourceData
+import com.cgfay.video.bean.EffectMimeType
+import com.cgfay.video.bean.EffectType
+
+@Composable
+fun EffectCategoryBar(
+    selected: EffectMimeType?,
+    onSelected: (EffectMimeType) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val categories = EffectMimeType.values().toList()
+    LazyRow(modifier = modifier) {
+        items(categories) { type ->
+            Text(
+                text = type.displayName,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .clickable { onSelected(type) },
+                color = if (selected == type) MaterialTheme.colors.primary else Color.White
+            )
+        }
+    }
+}
+
+@Composable
+fun VideoEffectList(
+    effects: List<EffectType>,
+    selectedIndex: Int,
+    onSelected: (Int, EffectType) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(modifier = modifier) {
+        itemsIndexed(effects) { index, effect ->
+            EffectItem(
+                effect = effect,
+                selected = index == selectedIndex,
+                onClick = { onSelected(index, effect) }
+            )
+        }
+    }
+}
+
+@Composable
+fun EffectItem(effect: EffectType, selected: Boolean, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .padding(8.dp)
+            .width(80.dp)
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            model = effect.getThumb(),
+            contentDescription = effect.getName(),
+            modifier = Modifier
+                .size(60.dp)
+                .background(if (selected) MaterialTheme.colors.primary else Color.Transparent),
+            contentScale = ContentScale.Crop
+        )
+        Text(text = effect.getName(), modifier = Modifier.padding(top = 4.dp))
+    }
+}
+
+@Composable
+fun VideoFilterList(
+    data: List<ResourceData>,
+    selectedIndex: Int,
+    onSelected: (Int, ResourceData) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(modifier = modifier) {
+        itemsIndexed(data) { index, filter ->
+            FilterItem(
+                filter = filter,
+                selected = index == selectedIndex,
+                onClick = { onSelected(index, filter) }
+            )
+        }
+    }
+}
+
+@Composable
+fun FilterItem(filter: ResourceData, selected: Boolean, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .padding(8.dp)
+            .width(80.dp)
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            model = filter.thumbPath,
+            contentDescription = filter.name,
+            modifier = Modifier
+                .size(60.dp)
+                .background(if (selected) MaterialTheme.colors.primary else Color.Transparent),
+            contentScale = ContentScale.Crop
+        )
+        Text(text = filter.name, modifier = Modifier.padding(top = 4.dp))
+    }
+}

--- a/videolibrary/src/main/java/com/cgfay/video/compose/VideoEditCompose.kt
+++ b/videolibrary/src/main/java/com/cgfay/video/compose/VideoEditCompose.kt
@@ -1,9 +1,6 @@
 package com.cgfay.video.compose
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +17,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.cgfay.video.bean.EffectMimeType
+import com.cgfay.video.compose.EffectCategoryBar
+import com.cgfay.video.compose.VideoEffectList
 import com.cgfay.video.widget.VideoTextureView
 
 @Composable
@@ -44,21 +43,16 @@ fun VideoEditScreen(
 ) {
     viewModel.setVideoPath(path)
     val selected by viewModel.selectedEffect.collectAsState()
+    val category by viewModel.category.collectAsState()
+    val effects by viewModel.effectList.collectAsState()
+    val selectedIndex by viewModel.selectedIndex.collectAsState()
 
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f)) {
             AndroidView(factory = { context -> VideoTextureView(context) }, modifier = Modifier.fillMaxSize())
         }
-        LazyRow(modifier = Modifier.fillMaxWidth().height(60.dp)) {
-            items(EffectMimeType.values()) { type ->
-                Text(
-                    text = type.displayName,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .clickable { viewModel.selectEffect(type.displayName) }
-                )
-            }
-        }
+        EffectCategoryBar(selected = category, onSelected = { viewModel.selectCategory(it) }, modifier = Modifier.fillMaxWidth())
+        VideoEffectList(effects = effects, selectedIndex = selectedIndex, onSelected = { index, effect -> viewModel.selectEffect(index) }, modifier = Modifier.height(80.dp).fillMaxWidth())
         Text(text = selected ?: "No effect", modifier = Modifier.padding(16.dp))
         Row(
             modifier = Modifier

--- a/videolibrary/src/main/java/com/cgfay/video/compose/VideoEditViewModel.kt
+++ b/videolibrary/src/main/java/com/cgfay/video/compose/VideoEditViewModel.kt
@@ -1,21 +1,53 @@
 package com.cgfay.video.compose
 
 import androidx.lifecycle.ViewModel
+import com.cgfay.filter.glfilter.resource.bean.ResourceData
+import com.cgfay.video.bean.EffectMimeType
+import com.cgfay.video.bean.EffectType
+import com.cgfay.video.fragment.EffectFilterHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class VideoEditViewModel : ViewModel() {
+
     private val _videoPath = MutableStateFlow("")
     val videoPath: StateFlow<String> get() = _videoPath
 
+    private val _category = MutableStateFlow(EffectMimeType.FILTER)
+    val category: StateFlow<EffectMimeType> get() = _category
+
+    private val _effectList = MutableStateFlow<List<EffectType>>(emptyList())
+    val effectList: StateFlow<List<EffectType>> get() = _effectList
+
+    private val _selectedIndex = MutableStateFlow(-1)
+    val selectedIndex: StateFlow<Int> get() = _selectedIndex
+
     private val _selectedEffect = MutableStateFlow<String?>(null)
     val selectedEffect: StateFlow<String?> get() = _selectedEffect
+
+    init {
+        // initialize with filter effects
+        _effectList.value = EffectFilterHelper.getInstance().getEffectFilterData()
+    }
 
     fun setVideoPath(path: String) {
         _videoPath.value = path
     }
 
-    fun selectEffect(effectName: String) {
-        _selectedEffect.value = effectName
+    fun selectCategory(category: EffectMimeType) {
+        _category.value = category
+        _selectedIndex.value = -1
+        _effectList.value = when (category) {
+            EffectMimeType.FILTER -> EffectFilterHelper.getInstance().getEffectFilterData()
+            EffectMimeType.TRANSITION -> EffectFilterHelper.getInstance().getEffectTransitionData()
+            EffectMimeType.MULTIFRAME -> EffectFilterHelper.getInstance().getEffectMultiData()
+            EffectMimeType.TIME -> emptyList()
+        }
+    }
+
+    fun selectEffect(index: Int) {
+        _selectedIndex.value = index
+        val effect = _effectList.value.getOrNull(index)
+        _selectedEffect.value = effect?.name
     }
 }


### PR DESCRIPTION
## Summary
- implement composable lists for effect/filter selections
- update video edit screen to use new composables and StateFlow
- add Coil image loader for Compose

## Testing
- `./gradlew :videolibrary:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822453c4e4832cad671c3b66024a1a