### PR TITLE
Add compose album & tab support

### DIFF
--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/MediaPickerScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -30,6 +32,7 @@ fun MediaPickerScreen(
     val mediaList by viewModel.mediaList.collectAsState()
     val selected by viewModel.selectedMedia.collectAsState()
     val album by viewModel.selectedAlbum.collectAsState()
+    val tab by viewModel.selectedTab.collectAsState()
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text(album?.displayName ?: "Media Picker") },
@@ -52,6 +55,18 @@ fun MediaPickerScreen(
                 }
             }
         )
+        TabRow(selectedTabIndex = tab.ordinal) {
+            Tab(
+                selected = tab == PickerTab.IMAGE,
+                onClick = { viewModel.selectTab(PickerTab.IMAGE) },
+                text = { Text("Images") }
+            )
+            Tab(
+                selected = tab == PickerTab.VIDEO,
+                onClick = { viewModel.selectTab(PickerTab.VIDEO) },
+                text = { Text("Videos") }
+            )
+        }
         LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier.weight(1f)) {
             items(mediaList) { media ->
                 Box(

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerComposeActivity.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerComposeActivity.kt
@@ -17,7 +17,7 @@ class PickerComposeActivity : ComponentActivity() {
         }
         setContent {
             MaterialTheme {
-                val factory = PickerViewModelFactory(this)
+                val factory = PickerViewModelFactory(this, pickerParam)
                 val pickerViewModel: PickerViewModel = viewModel(factory = factory)
                 PickerNavHost(pickerViewModel)
             }

--- a/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerViewModelFactory.kt
+++ b/pickerlibrary/src/main/java/com/cgfay/picker/compose/PickerViewModelFactory.kt
@@ -4,16 +4,23 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.loader.app.LoaderManager
+import com.cgfay.picker.MediaPickerParam
+import com.cgfay.picker.scanner.AlbumDataScanner
 import com.cgfay.picker.scanner.ImageDataScanner
 import com.cgfay.picker.scanner.VideoDataScanner
 
-class PickerViewModelFactory(private val activity: ComponentActivity) : ViewModelProvider.Factory {
+class PickerViewModelFactory(
+    private val activity: ComponentActivity,
+    private val param: MediaPickerParam
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(PickerViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
             return PickerViewModel(
+                param,
                 { receiver -> ImageDataScanner(activity, LoaderManager.getInstance(activity), receiver) },
-                { receiver -> VideoDataScanner(activity, LoaderManager.getInstance(activity), receiver) }
+                { receiver -> VideoDataScanner(activity, LoaderManager.getInstance(activity), receiver) },
+                { AlbumDataScanner(activity, LoaderManager.getInstance(activity), param) }
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")


### PR DESCRIPTION
## Summary
- extend PickerViewModel to handle album data and tabs
- update factory and activity to supply MediaPickerParam
- enhance MediaPickerScreen with TabRow for images/videos

## Testing
- `./gradlew :pickerlibrary:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688237399c34832c979ed451c52aeaa7