### PR TITLE
Refactor preview presenter interface

### DIFF
--- a/cameralibrary/src/main/java/com/cgfay/camera/PreviewBuilder.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/PreviewBuilder.java
@@ -3,7 +3,6 @@ package com.cgfay.camera;
 import android.app.Activity;
 import android.content.Intent;
 import android.hardware.Camera;
-import androidx.fragment.app.Fragment;
 
 import com.cgfay.cameralibrary.R;
 import com.cgfay.camera.activity.CameraActivity;
@@ -174,12 +173,7 @@ public final class PreviewBuilder {
             return;
         }
         Intent intent = new Intent(activity, CameraActivity.class);
-        Fragment fragment = mPreviewEngine.getFragment();
-        if (fragment != null) {
-            fragment.startActivity(intent);
-        } else {
-            activity.startActivity(intent);
-            activity.overridePendingTransition(R.anim.anim_slide_up, 0);
-        }
+        activity.startActivity(intent);
+        activity.overridePendingTransition(R.anim.anim_slide_up, 0);
     }
 }

--- a/cameralibrary/src/main/java/com/cgfay/camera/PreviewEngine.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/PreviewEngine.java
@@ -1,7 +1,6 @@
 package com.cgfay.camera;
 
 import android.app.Activity;
-import androidx.fragment.app.Fragment;
 
 import com.cgfay.camera.model.AspectRatio;
 
@@ -13,27 +12,13 @@ import java.lang.ref.WeakReference;
 public final class PreviewEngine {
 
     private WeakReference<Activity> mWeakActivity;
-    private WeakReference<Fragment> mWeakFragment;
 
     private PreviewEngine(Activity activity) {
-        this(activity, null);
-    }
-
-    private PreviewEngine(Fragment fragment) {
-        this(fragment.getActivity(), fragment);
-    }
-
-    private PreviewEngine(Activity activity, Fragment fragment) {
         mWeakActivity = new WeakReference<>(activity);
-        mWeakFragment = new WeakReference<>(fragment);
     }
 
     public static PreviewEngine from(Activity activity) {
         return new PreviewEngine(activity);
-    }
-
-    public static PreviewEngine from(Fragment fragment) {
-        return new PreviewEngine(fragment);
     }
 
     /**
@@ -47,10 +32,6 @@ public final class PreviewEngine {
 
     public Activity getActivity() {
         return mWeakActivity.get();
-    }
-
-    public Fragment getFragment() {
-        return mWeakFragment.get();
     }
 
 

--- a/cameralibrary/src/main/java/com/cgfay/camera/activity/CameraActivity.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/activity/CameraActivity.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.FragmentActivity
 import com.cgfay.cameralibrary.R
 import com.cgfay.camera.compose.CameraPreviewScreen
 import com.cgfay.camera.fragment.CameraPreviewFragment
+import com.cgfay.camera.presenter.CameraPreviewPresenter
 import com.cgfay.facedetect.engine.FaceTracker
 import com.cgfay.uitls.utils.NotchUtils
 
@@ -37,8 +38,9 @@ class CameraActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val presenter = CameraPreviewPresenter()
         setContent {
-            CameraPreviewScreen(fragmentTag = FRAGMENT_CAMERA)
+            CameraPreviewScreen(presenter = presenter, fragmentTag = FRAGMENT_CAMERA)
         }
         faceTrackerRequestNetwork()
     }

--- a/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraComposeActivity.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraComposeActivity.kt
@@ -3,12 +3,14 @@ package com.cgfay.camera.compose
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.cgfay.camera.presenter.CameraPreviewPresenter
 
 class CameraComposeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val presenter = CameraPreviewPresenter()
         setContent {
-            CameraPreviewScreen()
+            CameraPreviewScreen(presenter = presenter)
         }
     }
 }

--- a/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraPreviewComposable.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraPreviewComposable.kt
@@ -7,16 +7,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
 import com.cgfay.camera.fragment.CameraPreviewFragment
+import com.cgfay.camera.presenter.CameraPreviewPresenter
 
 @Composable
-fun CameraPreviewScreen(fragmentTag: String = "camera_compose") {
+fun CameraPreviewScreen(
+    presenter: CameraPreviewPresenter,
+    fragmentTag: String = "camera_compose"
+) {
     val context = LocalContext.current
     AndroidView(factory = {
         FrameLayout(it).apply {
             id = View.generateViewId()
             if (context is FragmentActivity) {
                 context.supportFragmentManager.beginTransaction()
-                    .replace(id, CameraPreviewFragment(), fragmentTag)
+                    .replace(id, CameraPreviewFragment(presenter), fragmentTag)
                     .commitNowAllowingStateLoss()
             }
         }

--- a/cameralibrary/src/main/java/com/cgfay/camera/fragment/CameraPreviewFragment.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/fragment/CameraPreviewFragment.java
@@ -58,12 +58,13 @@ import com.cgfay.uitls.utils.BrightnessUtils;
 import com.cgfay.uitls.utils.PermissionUtils;
 import com.cgfay.uitls.widget.RoundOutlineProvider;
 import com.cgfay.widget.CameraTabView;
+import com.cgfay.camera.presenter.CameraPreviewView;
 
 
 /**
  * 相机预览页面
  */
-public class CameraPreviewFragment extends Fragment implements View.OnClickListener, LoaderManager.LoaderCallbacks<Cursor> {
+public class CameraPreviewFragment extends Fragment implements View.OnClickListener, LoaderManager.LoaderCallbacks<Cursor>, CameraPreviewView {
 
     private static final String TAG = "CameraPreviewFragment";
     private static final boolean VERBOSE = true;
@@ -135,9 +136,16 @@ public class CameraPreviewFragment extends Fragment implements View.OnClickListe
     private Dialog mDialog;
 
     public CameraPreviewFragment() {
+        this(new CameraPreviewPresenter());
+    }
+
+    public CameraPreviewFragment(CameraPreviewPresenter presenter) {
         mCameraParam = CameraParam.getInstance();
         mMainHandler = new Handler(Looper.getMainLooper());
-        mPreviewPresenter = new CameraPreviewPresenter(this);
+        mPreviewPresenter = presenter;
+        if (mPreviewPresenter != null) {
+            mPreviewPresenter.setTarget(this);
+        }
     }
 
     @Override

--- a/cameralibrary/src/main/java/com/cgfay/camera/presenter/CameraPreviewPresenter.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/presenter/CameraPreviewPresenter.java
@@ -21,7 +21,7 @@ import com.cgfay.camera.camera.OnSurfaceTextureListener;
 import com.cgfay.camera.camera.PreviewCallback;
 import com.cgfay.camera.listener.OnCaptureListener;
 import com.cgfay.camera.listener.OnFpsListener;
-import com.cgfay.camera.fragment.CameraPreviewFragment;
+import com.cgfay.camera.presenter.CameraPreviewView;
 import com.cgfay.camera.listener.OnPreviewCaptureListener;
 import com.cgfay.camera.render.CameraRenderer;
 import com.cgfay.camera.utils.PathConstraints;
@@ -60,7 +60,7 @@ import java.util.List;
  * @author CainHuang
  * @date 2019/7/3
  */
-public class CameraPreviewPresenter extends PreviewPresenter<CameraPreviewFragment>
+public class CameraPreviewPresenter extends PreviewPresenter<CameraPreviewView>
         implements PreviewCallback, FaceTrackerCallback, OnCaptureListener, OnFpsListener,
         OnSurfaceTextureListener, OnFrameAvailableListener, OnRecordStateListener {
 
@@ -110,7 +110,7 @@ public class CameraPreviewPresenter extends PreviewPresenter<CameraPreviewFragme
     // 渲染器
     private final CameraRenderer mCameraRenderer;
 
-    public CameraPreviewPresenter(CameraPreviewFragment target) {
+    public CameraPreviewPresenter(CameraPreviewView target) {
         super(target);
         mCameraParam = CameraParam.getInstance();
 
@@ -122,6 +122,10 @@ public class CameraPreviewPresenter extends PreviewPresenter<CameraPreviewFragme
 
         // 命令行编辑器
         mCommandEditor = new CainCommandEditor();
+    }
+
+    public CameraPreviewPresenter() {
+        this((CameraPreviewView) null);
     }
 
     public void onAttach(FragmentActivity activity) {

--- a/cameralibrary/src/main/java/com/cgfay/camera/presenter/CameraPreviewView.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/presenter/CameraPreviewView.kt
@@ -1,0 +1,16 @@
+package com.cgfay.camera.presenter
+
+/**
+ * View interface for camera preview callbacks.
+ */
+interface CameraPreviewView {
+    fun deleteProgressSegment()
+    fun hideOnRecording()
+    fun updateRecordProgress(duration: Float)
+    fun addProgressSegment(progress: Float)
+    fun resetAllLayout()
+    fun showConcatProgressDialog()
+    fun hideConcatProgressDialog()
+    fun showToast(msg: String)
+    fun showFps(fps: Float)
+}

--- a/cameralibrary/src/main/java/com/cgfay/camera/presenter/IPresenter.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/presenter/IPresenter.java
@@ -16,6 +16,10 @@ public abstract class IPresenter <T> {
         mTarget = target;
     }
 
+    public void setTarget(T target) {
+        mTarget = target;
+    }
+
     public T getTarget() {
         return mTarget;
     }

--- a/cameralibrary/src/main/java/com/cgfay/camera/presenter/PreviewPresenter.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/presenter/PreviewPresenter.java
@@ -4,7 +4,8 @@ import android.graphics.SurfaceTexture;
 import android.opengl.EGLContext;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
+
+import com.cgfay.camera.presenter.CameraPreviewView;
 
 import com.cgfay.filter.glfilter.color.bean.DynamicColor;
 import com.cgfay.filter.glfilter.makeup.bean.DynamicMakeup;
@@ -16,7 +17,7 @@ import com.cgfay.media.recorder.SpeedMode;
  * @author CainHuang
  * @date 2019/7/3
  */
-public abstract class PreviewPresenter<T extends Fragment> extends IPresenter<T> {
+public abstract class PreviewPresenter<T extends CameraPreviewView> extends IPresenter<T> {
 
     PreviewPresenter(T target) {
         super(target);


### PR DESCRIPTION
## Summary
- add `CameraPreviewView` interface for presenter callbacks
- remove fragment dependency from `PreviewEngine` and `PreviewBuilder`
- create new presenter injection API for compose previews
- pass presenter from activities into `CameraPreviewScreen`

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882460be900832c9247ff52fbb83af2