### PR TITLE
Refactor record screens to use ViewModel state

### DIFF
--- a/app/src/main/java/com/cgfay/caincamera/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/cgfay/caincamera/viewmodel/RecordViewModel.kt
@@ -180,7 +180,7 @@ class RecordViewModel(private val activity: BaseRecordActivity) : ViewModel(),
     }
 
     override fun onFrameAvailable(surfaceTexture: SurfaceTexture) {
-        _uiState.value = _uiState.value.copy(frameAvailable = true)
+        _uiState.value = _uiState.value.copy(frameAvailable = !_uiState.value.frameAvailable)
     }
 
     fun deleteLastVideo() {


### PR DESCRIPTION
## Summary
- obtain RecordViewModel instances via ViewModelProvider
- observe `uiState` in SpeedRecordActivity and DuetRecordActivity screens
- update Compose UIs to use state instead of callbacks
- expose state from FFMediaRecordViewModel and refactor Compose screen
- toggle frame update state in RecordViewModel

## Testing
- `./gradlew -q tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688250c177a0832cab3f71c1f10c966d