### PR TITLE
Remove fragment requirement for preview engine

### DIFF
--- a/cameralibrary/src/main/java/com/cgfay/camera/PreviewBuilder.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/PreviewBuilder.java
@@ -3,7 +3,6 @@ package com.cgfay.camera;
 import android.app.Activity;
 import android.content.Intent;
 import android.hardware.Camera;
-import androidx.fragment.app.Fragment;
 
 import com.cgfay.cameralibrary.R;
 import com.cgfay.camera.activity.CameraActivity;
@@ -174,12 +173,7 @@ public final class PreviewBuilder {
             return;
         }
         Intent intent = new Intent(activity, CameraActivity.class);
-        Fragment fragment = mPreviewEngine.getFragment();
-        if (fragment != null) {
-            fragment.startActivity(intent);
-        } else {
-            activity.startActivity(intent);
-            activity.overridePendingTransition(R.anim.anim_slide_up, 0);
-        }
+        activity.startActivity(intent);
+        activity.overridePendingTransition(R.anim.anim_slide_up, 0);
     }
 }

--- a/cameralibrary/src/main/java/com/cgfay/camera/PreviewEngine.java
+++ b/cameralibrary/src/main/java/com/cgfay/camera/PreviewEngine.java
@@ -1,7 +1,6 @@
 package com.cgfay.camera;
 
 import android.app.Activity;
-import androidx.fragment.app.Fragment;
 
 import com.cgfay.camera.model.AspectRatio;
 
@@ -13,28 +12,15 @@ import java.lang.ref.WeakReference;
 public final class PreviewEngine {
 
     private WeakReference<Activity> mWeakActivity;
-    private WeakReference<Fragment> mWeakFragment;
 
     private PreviewEngine(Activity activity) {
-        this(activity, null);
-    }
-
-    private PreviewEngine(Fragment fragment) {
-        this(fragment.getActivity(), fragment);
-    }
-
-    private PreviewEngine(Activity activity, Fragment fragment) {
         mWeakActivity = new WeakReference<>(activity);
-        mWeakFragment = new WeakReference<>(fragment);
     }
 
     public static PreviewEngine from(Activity activity) {
         return new PreviewEngine(activity);
     }
 
-    public static PreviewEngine from(Fragment fragment) {
-        return new PreviewEngine(fragment);
-    }
 
     /**
      * 设置长宽比
@@ -49,9 +35,6 @@ public final class PreviewEngine {
         return mWeakActivity.get();
     }
 
-    public Fragment getFragment() {
-        return mWeakFragment.get();
-    }
 
 
 }

--- a/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraPreviewViewModel.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/compose/CameraPreviewViewModel.kt
@@ -5,7 +5,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
-class CameraPreviewViewModel : ViewModel() {
+import com.cgfay.camera.presenter.CameraPreviewView
+
+/**
+ * ViewModel used by [CameraActivity] and related composables. It also acts as
+ * the [CameraPreviewView] implementation so the presenter can dispatch
+ * callbacks without requiring a Fragment instance.
+ */
+class CameraPreviewViewModel : ViewModel(), CameraPreviewView {
 
     var showResourcePanel by mutableStateOf(false)
         private set


### PR DESCRIPTION
## Summary
- implement `CameraPreviewView` via `CameraPreviewViewModel`
- drop Fragment usage from `PreviewEngine`
- simplify `startPreview()` to always start `CameraActivity`

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d5199590832cbd377cda88cb05ee