### PR TITLE
Replace deprecated jcenter repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ apply(from = "versions.gradle.kts")
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         // Updated to support compileSdk 35
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         flatDir {
             dirs("libs")
         }


### PR DESCRIPTION
## Summary
- remove jcenter() usage in favor of mavenCentral()

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882f61cc980832cb0baaab0c721936a