### PR TITLE
Migrate camera model enums to Kotlin

### DIFF
--- a/cameralibrary/src/main/java/com/cgfay/camera/model/AspectRatio.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/model/AspectRatio.kt
@@ -1,10 +1,10 @@
-package com.cgfay.camera.model;
+package com.cgfay.camera.model
 
 /**
  * 长宽比
  * Created by cain.huang on 2017/7/27.
  */
-public enum AspectRatio {
+enum class AspectRatio {
     RATIO_4_3,
     RATIO_1_1,
     Ratio_16_9

--- a/cameralibrary/src/main/java/com/cgfay/camera/model/GalleryType.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/model/GalleryType.kt
@@ -1,9 +1,9 @@
-package com.cgfay.camera.model;
+package com.cgfay.camera.model
 
 /**
  * Created by cain.huang on 2017/9/28.
  */
-public enum GalleryType {
+enum class GalleryType {
     PICTURE,        // 图片
     VIDEO_60S,      // 拍60秒
     VIDEO_15S,      // 拍15秒


### PR DESCRIPTION
## Summary
- rewrite `AspectRatio` and `GalleryType` as Kotlin enums
- remove the old Java files

## Testing
- `./gradlew :cameralibrary:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688339ec5590832c99defdcf2c5f71d5