### PR TITLE
Convert Shape2D to Kotlin

### DIFF
--- a/gdxlibrary/build.gradle.kts
+++ b/gdxlibrary/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.library")
+    id("kotlin-android")
 }
 
 android {
@@ -46,6 +47,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/gdxlibrary/src/main/java/com/badlogic/gdx/math/Shape2D.kt
+++ b/gdxlibrary/src/main/java/com/badlogic/gdx/math/Shape2D.kt
@@ -1,11 +1,9 @@
-package com.badlogic.gdx.math;
+package com.badlogic.gdx.math
 
-public interface Shape2D {
-
+interface Shape2D {
     /** Returns whether the given point is contained within the shape. */
-    boolean contains(Vector2 point);
+    fun contains(point: Vector2): Boolean
 
     /** Returns whether a point with the given coordinates is contained within the shape. */
-    boolean contains(float x, float y);
-
+    fun contains(x: Float, y: Float): Boolean
 }


### PR DESCRIPTION
## Summary
- convert `Shape2D.java` to Kotlin
- enable Kotlin support in `gdxlibrary` by applying the Kotlin plugin

## Testing
- `./gradlew :gdxlibrary:test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883540db1ec832cad7fd66725398d9e