### PR TITLE
Remove adapter folder and move Compose lists to widget

### DIFF
--- a/cameralibrary/src/main/java/com/cgfay/camera/compose/PreviewEffectScreen.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/compose/PreviewEffectScreen.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import com.cgfay.camera.adapter.BeautyList
-import com.cgfay.camera.adapter.FilterGrid
-import com.cgfay.camera.adapter.MakeupList
+import com.cgfay.camera.widget.BeautyList
+import com.cgfay.camera.widget.FilterGrid
+import com.cgfay.camera.widget.MakeupList
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Slider

--- a/cameralibrary/src/main/java/com/cgfay/camera/widget/PreviewLists.kt
+++ b/cameralibrary/src/main/java/com/cgfay/camera/widget/PreviewLists.kt
@@ -1,4 +1,4 @@
-package com.cgfay.camera.adapter
+package com.cgfay.camera.widget
 
 import android.net.Uri
 import androidx.compose.foundation.background


### PR DESCRIPTION
## Summary
- move `PreviewLists.kt` into the `widget` package
- remove obsolete `adapter` directory
- update `PreviewEffectScreen` imports

## Testing
- `./gradlew :cameralibrary:assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68844eb854c4832ca0cdf1062297ba5c