### PR TITLE
Remove finalize methods, use Closeable

### DIFF
--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
@@ -3,11 +3,12 @@ package com.cgfay.media;
 import androidx.annotation.NonNull;
 
 import com.cgfay.uitls.utils.FileUtils;
+import java.io.Closeable;
 
 /**
  * 媒体编辑器
  */
-public class CainMediaEditor {
+public class CainMediaEditor implements Closeable {
 
     private static final String TAG = "CainMediaEditor";
 
@@ -35,11 +36,6 @@ public class CainMediaEditor {
         handle = nativeInit();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        release();
-        super.finalize();
-    }
 
     /**
      * 释放资源
@@ -49,6 +45,11 @@ public class CainMediaEditor {
             nativeRelease(handle);
             handle = 0;
         }
+    }
+
+    @Override
+    public void close() {
+        release();
     }
 
     /**

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
@@ -18,6 +18,7 @@ import android.view.SurfaceHolder;
 
 import com.cgfay.media.annotations.AccessedByNative;
 
+import java.io.Closeable;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -28,7 +29,7 @@ import java.util.Map;
  * 播放器的实现仿照MediaPlayer 的实现逻辑
  * 详情请参考 android.media.MediaPlayer.java 和 android_media_MediaPlayer.cpp
  */
-public class CainMediaPlayer implements IMediaPlayer {
+public class CainMediaPlayer implements IMediaPlayer, Closeable {
 
     /**
      Constant to retrieve only the new metadata since the last
@@ -688,6 +689,11 @@ public class CainMediaPlayer implements IMediaPlayer {
         _release();
     }
 
+    @Override
+    public void close() {
+        release();
+    }
+
     private native void _release();
 
     /**
@@ -906,12 +912,6 @@ public class CainMediaPlayer implements IMediaPlayer {
     private static native void native_init();
     private native void native_setup(Object mediaplayer_this);
     private native void native_finalize();
-
-    @Override
-    protected void finalize() throws Throwable {
-        native_finalize();
-        super.finalize();
-    }
 
     /* Do not change these values without updating their counterparts
      * in include/media/mediaplayer.h!

--- a/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
@@ -9,10 +9,11 @@ import androidx.annotation.NonNull;
 
 import com.cgfay.media.annotations.AccessedByNative;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 
-public class MusicPlayer {
+public class MusicPlayer implements Closeable {
 
     private static final String TAG = "MusicPlayer";
 
@@ -82,6 +83,11 @@ public class MusicPlayer {
         mOnErrorListener = null;
         mOnCurrentPositionListener = null;
         _release();
+    }
+
+    @Override
+    public void close() {
+        release();
     }
 
     /**
@@ -187,11 +193,6 @@ public class MusicPlayer {
         return _isPlaying();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        native_finalize();
-        super.finalize();
-    }
 
     /* Do not change these values without updating their counterparts
      * in MusicPlayer.h!

--- a/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
+++ b/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
@@ -5,7 +5,9 @@ package com.cgfay.media;
  * @author CainHuang
  * @date 2019/6/30
  */
-public class SoundTouch {
+import java.io.Closeable;
+
+public class SoundTouch implements Closeable {
 
     static {
         System.loadLibrary("soundtouch");
@@ -94,16 +96,10 @@ public class SoundTouch {
         return receiveSamples(handle, output, output.length);
     }
 
+    @Override
     public void close() {
         nativeRelease(handle);
         handle = 0;
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        if (handle != 0) {
-            close();
-        }
-        super.finalize();
-    }
 }


### PR DESCRIPTION
## Summary
- implement `Closeable` in `CainMediaEditor`, `CainMediaPlayer`, `MusicPlayer`, and `SoundTouch`
- remove finalizers from these classes
- add `close()` methods delegating to existing `release()`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688453adbe6c832c9b04e23c45034ea5