### PR TITLE
Improve native library loading

### DIFF
--- a/filterlibrary/src/main/java/com/cgfay/filter/ndkfilter/ImageFilter.kt
+++ b/filterlibrary/src/main/java/com/cgfay/filter/ndkfilter/ImageFilter.kt
@@ -1,14 +1,21 @@
 package com.cgfay.filter.ndkfilter
 
 import android.graphics.Bitmap
+import android.util.Log
 
 /**
  * Image filters implemented with native code.
  */
 object ImageFilter {
+    private const val TAG = "ImageFilter"
 
     init {
-        System.loadLibrary("nativefilter")
+        try {
+            System.loadLibrary("nativefilter")
+        } catch (e: UnsatisfiedLinkError) {
+            Log.e(TAG, "Failed to load native library nativefilter", e)
+            throw RuntimeException("Failed to load native library: nativefilter", e)
+        }
     }
 
     /** Obtain the singleton instance for Java callers. */

--- a/gdxlibrary/src/main/java/com/badlogic/gdx/math/Matrix4.java
+++ b/gdxlibrary/src/main/java/com/badlogic/gdx/math/Matrix4.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
  * </pre>
  *
  * @author badlogicgames@gmail.com */
+import android.util.Log;
+
 public class Matrix4 implements Serializable {
     private static final long serialVersionUID = -2717655254359579617L;
     /** XX: Typically the unrotated X component for scaling, also the cosine of the angle when rotated on the Y and/or Z axis. On
@@ -1551,7 +1553,14 @@ public class Matrix4 implements Serializable {
                 && MathUtils.isZero(val[M20]) && MathUtils.isZero(val[M21]));
     }
 
+    private static final String TAG = "Matrix4";
+
     static {
-        System.loadLibrary("nativegdx");
+        try {
+            System.loadLibrary("nativegdx");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library nativegdx", e);
+            throw new RuntimeException("Failed to load native library: nativegdx", e);
+        }
     }
 }

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
@@ -2,6 +2,8 @@ package com.cgfay.media;
 
 import androidx.annotation.NonNull;
 
+import android.util.Log;
+
 import com.cgfay.uitls.utils.FileUtils;
 
 /**
@@ -12,10 +14,30 @@ public class CainMediaEditor {
     private static final String TAG = "CainMediaEditor";
 
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("soundtouch");
-        System.loadLibrary("yuv");
-        System.loadLibrary("media_editor");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("soundtouch");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library soundtouch", e);
+            throw new RuntimeException("Failed to load native library: soundtouch", e);
+        }
+        try {
+            System.loadLibrary("yuv");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library yuv", e);
+            throw new RuntimeException("Failed to load native library: yuv", e);
+        }
+        try {
+            System.loadLibrary("media_editor");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library media_editor", e);
+            throw new RuntimeException("Failed to load native library: media_editor", e);
+        }
     }
 
     // 初始化

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaMetadataRetriever.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaMetadataRetriever.java
@@ -6,6 +6,7 @@ import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.util.Log;
 
 import com.cgfay.media.annotations.AccessedByNative;
 import com.cgfay.uitls.utils.BitmapUtils;
@@ -23,9 +24,21 @@ import java.util.Map;
  */
 public class CainMediaMetadataRetriever {
 
+    private static final String TAG = "CainMediaMetadataRetriever";
+
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("metadata_retriever");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("metadata_retriever");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library metadata_retriever", e);
+            throw new RuntimeException("Failed to load native library: metadata_retriever", e);
+        }
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
@@ -63,15 +63,35 @@ public class CainMediaPlayer implements IMediaPlayer {
      */
     public static final boolean BYPASS_METADATA_FILTER = false;
 
+    private static final String TAG = "CainMediaPlayer";
+
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("soundtouch");
-        System.loadLibrary("yuv");
-        System.loadLibrary("media_player");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("soundtouch");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library soundtouch", e);
+            throw new RuntimeException("Failed to load native library: soundtouch", e);
+        }
+        try {
+            System.loadLibrary("yuv");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library yuv", e);
+            throw new RuntimeException("Failed to load native library: yuv", e);
+        }
+        try {
+            System.loadLibrary("media_player");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library media_player", e);
+            throw new RuntimeException("Failed to load native library: media_player", e);
+        }
         native_init();
     }
-
-    private static final String TAG = "CainMediaPlayer";
 
     @AccessedByNative
     private long mNativeContext;

--- a/medialibrary/src/main/java/com/cgfay/media/FFmpegUtils.java
+++ b/medialibrary/src/main/java/com/cgfay/media/FFmpegUtils.java
@@ -1,14 +1,28 @@
 package com.cgfay.media;
 
+import android.util.Log;
+
 /**
  * @author CainHuang
  * @date 2019/6/7
  */
 public final class FFmpegUtils {
 
+    private static final String TAG = "FFmpegUtils";
+
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("ffcommand");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("ffcommand");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffcommand", e);
+            throw new RuntimeException("Failed to load native library: ffcommand", e);
+        }
     }
 
     private FFmpegUtils() {}

--- a/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
@@ -17,8 +17,18 @@ public class MusicPlayer {
     private static final String TAG = "MusicPlayer";
 
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("musicplayer");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("musicplayer");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library musicplayer", e);
+            throw new RuntimeException("Failed to load native library: musicplayer", e);
+        }
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
+++ b/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
@@ -1,5 +1,7 @@
 package com.cgfay.media;
 
+import android.util.Log;
+
 /**
  * SoundTouch库
  * @author CainHuang
@@ -7,8 +9,15 @@ package com.cgfay.media;
  */
 public class SoundTouch {
 
+    private static final String TAG = "SoundTouch";
+
     static {
-        System.loadLibrary("soundtouch");
+        try {
+            System.loadLibrary("soundtouch");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library soundtouch", e);
+            throw new RuntimeException("Failed to load native library: soundtouch", e);
+        }
     }
 
     // 初始化

--- a/medialibrary/src/main/java/com/cgfay/media/VideoPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/VideoPlayer.java
@@ -31,9 +31,24 @@ public class VideoPlayer implements IMediaPlayer {
     private static final String TAG = "VideoPlayer";
 
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("yuv");
-        System.loadLibrary("videoplayer");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("yuv");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library yuv", e);
+            throw new RuntimeException("Failed to load native library: yuv", e);
+        }
+        try {
+            System.loadLibrary("videoplayer");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library videoplayer", e);
+            throw new RuntimeException("Failed to load native library: videoplayer", e);
+        }
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/recorder/FFMediaRecorder.java
+++ b/medialibrary/src/main/java/com/cgfay/media/recorder/FFMediaRecorder.java
@@ -19,11 +19,33 @@ import java.util.concurrent.Executors;
  */
 public final class FFMediaRecorder {
 
+    private static final String TAG = "FFMediaRecorder";
+
     static {
-        System.loadLibrary("ffmpeg");
-        System.loadLibrary("soundtouch");
-        System.loadLibrary("yuv");
-        System.loadLibrary("ffrecorder");
+        try {
+            System.loadLibrary("ffmpeg");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffmpeg", e);
+            throw new RuntimeException("Failed to load native library: ffmpeg", e);
+        }
+        try {
+            System.loadLibrary("soundtouch");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library soundtouch", e);
+            throw new RuntimeException("Failed to load native library: soundtouch", e);
+        }
+        try {
+            System.loadLibrary("yuv");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library yuv", e);
+            throw new RuntimeException("Failed to load native library: yuv", e);
+        }
+        try {
+            System.loadLibrary("ffrecorder");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(TAG, "Failed to load native library ffrecorder", e);
+            throw new RuntimeException("Failed to load native library: ffrecorder", e);
+        }
     }
 
     // 初始化


### PR DESCRIPTION
## Summary
- guard all `System.loadLibrary` calls with try/catch
- log errors when libraries fail to load
- throw RuntimeException to notify callers

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688453b0d574832caa6c003b3cc4d61c