### PR TITLE
Implement Closeable resource release

### DIFF
--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
@@ -9,7 +9,9 @@ import com.cgfay.uitls.utils.FileUtils;
 /**
  * 媒体编辑器
  */
-public class CainMediaEditor {
+import java.io.Closeable;
+
+public class CainMediaEditor implements Closeable {
 
     private static final String TAG = "CainMediaEditor";
 
@@ -57,12 +59,6 @@ public class CainMediaEditor {
         handle = nativeInit();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        release();
-        super.finalize();
-    }
-
     /**
      * 释放资源
      */
@@ -71,6 +67,11 @@ public class CainMediaEditor {
             nativeRelease(handle);
             handle = 0;
         }
+    }
+
+    @Override
+    public void close() {
+        release();
     }
 
     /**

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
@@ -31,7 +31,9 @@ import java.util.Map;
  * 播放器的实现仿照MediaPlayer 的实现逻辑
  * 详情请参考 android.media.MediaPlayer.java 和 android_media_MediaPlayer.cpp
  */
-public class CainMediaPlayer implements IMediaPlayer {
+import java.io.Closeable;
+
+public class CainMediaPlayer implements IMediaPlayer, Closeable {
 
     /**
      Constant to retrieve only the new metadata since the last
@@ -711,6 +713,11 @@ public class CainMediaPlayer implements IMediaPlayer {
         _release();
     }
 
+    @Override
+    public void close() {
+        release();
+    }
+
     private native void _release();
 
     /**
@@ -924,12 +931,6 @@ public class CainMediaPlayer implements IMediaPlayer {
     private static native void native_init();
     private native void native_setup(Object mediaplayer_this);
     private native void native_finalize();
-
-    @Override
-    protected void finalize() throws Throwable {
-        native_finalize();
-        super.finalize();
-    }
 
     private static void postEventFromNative(Object mediaplayer_ref,
                                             int what, int arg1, int arg2, Object obj) {

--- a/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
@@ -9,10 +9,11 @@ import androidx.annotation.NonNull;
 
 import com.cgfay.media.annotations.AccessedByNative;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 
-public class MusicPlayer {
+public class MusicPlayer implements Closeable {
 
     private static final String TAG = "MusicPlayer";
 
@@ -92,6 +93,11 @@ public class MusicPlayer {
         mOnErrorListener = null;
         mOnCurrentPositionListener = null;
         _release();
+    }
+
+    @Override
+    public void close() {
+        release();
     }
 
     /**
@@ -197,11 +203,6 @@ public class MusicPlayer {
         return _isPlaying();
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        native_finalize();
-        super.finalize();
-    }
 
     /* Do not change these values without updating their counterparts
      * in MusicPlayer.h!

--- a/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
+++ b/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
@@ -7,7 +7,9 @@ import android.util.Log;
  * @author CainHuang
  * @date 2019/6/30
  */
-public class SoundTouch {
+import java.io.Closeable;
+
+public class SoundTouch implements Closeable {
 
     private static final String TAG = "SoundTouch";
 
@@ -103,16 +105,14 @@ public class SoundTouch {
         return receiveSamples(handle, output, output.length);
     }
 
-    public void close() {
+    public void release() {
         nativeRelease(handle);
         handle = 0;
     }
 
     @Override
-    protected void finalize() throws Throwable {
-        if (handle != 0) {
-            close();
-        }
-        super.finalize();
+    public void close() {
+        release();
     }
+
 }


### PR DESCRIPTION
## Summary
- implement `Closeable` in CainMediaEditor and provide a `close()` method
- implement `Closeable` in CainMediaPlayer and add a `close()` method
- implement `Closeable` in MusicPlayer and add a `close()` method
- implement `Closeable` in SoundTouch with new `release()` and `close()` methods
- remove all overridden `finalize()` methods from these classes

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884638c43f0832c8da300791ae8dc85