### PR TITLE
Convert root build.gradle to Kotlin DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-apply from: "versions.gradle.kts"
+apply(from = "versions.gradle.kts")
 
 buildscript {
     repositories {
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         // Updated to support compileSdk 35
-        classpath 'com.android.tools.build:gradle:8.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"
+        classpath("com.android.tools.build:gradle:8.3.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -20,11 +20,11 @@ allprojects {
         google()
         mavenCentral()
         flatDir {
-            dirs 'libs'
+            dirs("libs")
         }
     }
 }
 
-tasks.register('clean', Delete) {
-    delete rootProject.buildDir
+tasks.register<Delete>("clean") {
+    delete(rootProject.buildDir)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.buildFileName = "build.gradle.kt"
+rootProject.buildFileName = "build.gradle.kts"
 
 include(
     ":app",


### PR DESCRIPTION
## Summary
- rename `build.gradle.kt` to `build.gradle.kts`
- rewrite Gradle build script using Kotlin DSL
- update settings to reference the new build file name

## Testing
- `./gradlew help` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688469d0f3b4832ca6e476bc60a801b0