### PR TITLE
Centralize native library loading

### DIFF
--- a/filterlibrary/src/main/java/com/cgfay/filter/ndkfilter/ImageFilter.kt
+++ b/filterlibrary/src/main/java/com/cgfay/filter/ndkfilter/ImageFilter.kt
@@ -2,6 +2,7 @@ package com.cgfay.filter.ndkfilter
 
 import android.graphics.Bitmap
 import android.util.Log
+import com.cgfay.uitls.utils.NativeLibraryLoader
 
 /**
  * Image filters implemented with native code.
@@ -10,12 +11,7 @@ object ImageFilter {
     private const val TAG = "ImageFilter"
 
     init {
-        try {
-            System.loadLibrary("nativefilter")
-        } catch (e: UnsatisfiedLinkError) {
-            Log.e(TAG, "Failed to load native library nativefilter", e)
-            throw RuntimeException("Failed to load native library: nativefilter", e)
-        }
+        NativeLibraryLoader.loadLibraries("nativefilter")
     }
 
     /** Obtain the singleton instance for Java callers. */

--- a/gdxlibrary/src/main/java/com/badlogic/gdx/math/Matrix4.java
+++ b/gdxlibrary/src/main/java/com/badlogic/gdx/math/Matrix4.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
  *
  * @author badlogicgames@gmail.com */
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 public class Matrix4 implements Serializable {
     private static final long serialVersionUID = -2717655254359579617L;
@@ -1556,11 +1557,6 @@ public class Matrix4 implements Serializable {
     private static final String TAG = "Matrix4";
 
     static {
-        try {
-            System.loadLibrary("nativegdx");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library nativegdx", e);
-            throw new RuntimeException("Failed to load native library: nativegdx", e);
-        }
+        NativeLibraryLoader.loadLibraries("nativegdx");
     }
 }

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaEditor.java
@@ -3,6 +3,7 @@ package com.cgfay.media;
 import androidx.annotation.NonNull;
 
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 import com.cgfay.uitls.utils.FileUtils;
 
@@ -16,30 +17,12 @@ public class CainMediaEditor implements Closeable {
     private static final String TAG = "CainMediaEditor";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("soundtouch");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library soundtouch", e);
-            throw new RuntimeException("Failed to load native library: soundtouch", e);
-        }
-        try {
-            System.loadLibrary("yuv");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library yuv", e);
-            throw new RuntimeException("Failed to load native library: yuv", e);
-        }
-        try {
-            System.loadLibrary("media_editor");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library media_editor", e);
-            throw new RuntimeException("Failed to load native library: media_editor", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "soundtouch",
+                "yuv",
+                "media_editor"
+        );
     }
 
     // 初始化

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaMetadataRetriever.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaMetadataRetriever.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 import com.cgfay.media.annotations.AccessedByNative;
 import com.cgfay.uitls.utils.BitmapUtils;
@@ -27,18 +28,10 @@ public class CainMediaMetadataRetriever {
     private static final String TAG = "CainMediaMetadataRetriever";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("metadata_retriever");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library metadata_retriever", e);
-            throw new RuntimeException("Failed to load native library: metadata_retriever", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "metadata_retriever"
+        );
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/CainMediaPlayer.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
 import android.util.Log;
 import android.view.Surface;
 import android.view.SurfaceHolder;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 import com.cgfay.media.command.CainEventHandler;
 import com.cgfay.media.CainMediaPlayerEventsKt;
@@ -71,30 +72,12 @@ public class CainMediaPlayer implements IMediaPlayer, Closeable {
     private static final String TAG = "CainMediaPlayer";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("soundtouch");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library soundtouch", e);
-            throw new RuntimeException("Failed to load native library: soundtouch", e);
-        }
-        try {
-            System.loadLibrary("yuv");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library yuv", e);
-            throw new RuntimeException("Failed to load native library: yuv", e);
-        }
-        try {
-            System.loadLibrary("media_player");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library media_player", e);
-            throw new RuntimeException("Failed to load native library: media_player", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "soundtouch",
+                "yuv",
+                "media_player"
+        );
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/FFmpegUtils.java
+++ b/medialibrary/src/main/java/com/cgfay/media/FFmpegUtils.java
@@ -1,6 +1,7 @@
 package com.cgfay.media;
 
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 /**
  * @author CainHuang
@@ -11,18 +12,10 @@ public final class FFmpegUtils {
     private static final String TAG = "FFmpegUtils";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("ffcommand");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffcommand", e);
-            throw new RuntimeException("Failed to load native library: ffcommand", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "ffcommand"
+        );
     }
 
     private FFmpegUtils() {}

--- a/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/MusicPlayer.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 import androidx.annotation.NonNull;
 
@@ -18,18 +19,10 @@ public class MusicPlayer implements Closeable {
     private static final String TAG = "MusicPlayer";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("musicplayer");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library musicplayer", e);
-            throw new RuntimeException("Failed to load native library: musicplayer", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "musicplayer"
+        );
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
+++ b/medialibrary/src/main/java/com/cgfay/media/SoundTouch.java
@@ -1,6 +1,7 @@
 package com.cgfay.media;
 
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 
 /**
  * SoundTouch库
@@ -14,12 +15,7 @@ public class SoundTouch implements Closeable {
     private static final String TAG = "SoundTouch";
 
     static {
-        try {
-            System.loadLibrary("soundtouch");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library soundtouch", e);
-            throw new RuntimeException("Failed to load native library: soundtouch", e);
-        }
+        NativeLibraryLoader.loadLibraries("soundtouch");
     }
 
     // 初始化

--- a/medialibrary/src/main/java/com/cgfay/media/VideoPlayer.java
+++ b/medialibrary/src/main/java/com/cgfay/media/VideoPlayer.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 import android.os.Message;
 import android.os.PowerManager;
 import android.util.Log;
+import com.cgfay.uitls.utils.NativeLibraryLoader;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
@@ -31,24 +32,11 @@ public class VideoPlayer implements IMediaPlayer {
     private static final String TAG = "VideoPlayer";
 
     static {
-        try {
-            System.loadLibrary("ffmpeg");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library ffmpeg", e);
-            throw new RuntimeException("Failed to load native library: ffmpeg", e);
-        }
-        try {
-            System.loadLibrary("yuv");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library yuv", e);
-            throw new RuntimeException("Failed to load native library: yuv", e);
-        }
-        try {
-            System.loadLibrary("videoplayer");
-        } catch (UnsatisfiedLinkError e) {
-            Log.e(TAG, "Failed to load native library videoplayer", e);
-            throw new RuntimeException("Failed to load native library: videoplayer", e);
-        }
+        NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "yuv",
+                "videoplayer"
+        );
         native_init();
     }
 

--- a/medialibrary/src/main/java/com/cgfay/media/recorder/FFMediaRecorder.kt
+++ b/medialibrary/src/main/java/com/cgfay/media/recorder/FFMediaRecorder.kt
@@ -1,6 +1,7 @@
 package com.cgfay.media.recorder
 
 import android.util.Log
+import com.cgfay.uitls.utils.NativeLibraryLoader
 
 /**
  * Kotlin version of FFMediaRecorder that uses native ffmpeg based recorder.
@@ -14,30 +15,12 @@ class FFMediaRecorder private constructor() : AutoCloseable {
         private const val TAG = "FFMediaRecorder"
 
         init {
-            try {
-                System.loadLibrary("ffmpeg")
-            } catch (e: UnsatisfiedLinkError) {
-                Log.e(TAG, "Failed to load native library ffmpeg", e)
-                throw RuntimeException("Failed to load native library: ffmpeg", e)
-            }
-            try {
-                System.loadLibrary("soundtouch")
-            } catch (e: UnsatisfiedLinkError) {
-                Log.e(TAG, "Failed to load native library soundtouch", e)
-                throw RuntimeException("Failed to load native library: soundtouch", e)
-            }
-            try {
-                System.loadLibrary("yuv")
-            } catch (e: UnsatisfiedLinkError) {
-                Log.e(TAG, "Failed to load native library yuv", e)
-                throw RuntimeException("Failed to load native library: yuv", e)
-            }
-            try {
-                System.loadLibrary("ffrecorder")
-            } catch (e: UnsatisfiedLinkError) {
-                Log.e(TAG, "Failed to load native library ffrecorder", e)
-                throw RuntimeException("Failed to load native library: ffrecorder", e)
-            }
+            NativeLibraryLoader.loadLibraries(
+                "ffmpeg",
+                "soundtouch",
+                "yuv",
+                "ffrecorder"
+            )
         }
     }
 

--- a/utilslibrary/src/main/java/com/cgfay/uitls/utils/NativeLibraryLoader.kt
+++ b/utilslibrary/src/main/java/com/cgfay/uitls/utils/NativeLibraryLoader.kt
@@ -1,0 +1,27 @@
+package com.cgfay.uitls.utils
+
+import android.util.Log
+
+/**
+ * Loads native libraries once and caches the result.
+ */
+object NativeLibraryLoader {
+    private const val TAG = "NativeLibraryLoader"
+    private val loadedLibraries = HashSet<String>()
+
+    @JvmStatic
+    fun loadLibraries(vararg libraries: String) {
+        for (lib in libraries) {
+            if (loadedLibraries.contains(lib)) {
+                continue
+            }
+            try {
+                System.loadLibrary(lib)
+                loadedLibraries.add(lib)
+            } catch (e: UnsatisfiedLinkError) {
+                Log.e(TAG, "Failed to load native library $lib", e)
+                throw RuntimeException("Failed to load native library: $lib", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `NativeLibraryLoader` utility
- delegate native library loading to `NativeLibraryLoader`
- remove duplicated `System.loadLibrary` calls from each class

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688469d1c870832cbad352377fdc665f