### PR TITLE
Add compose instrumentation tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,4 +81,6 @@ dependencies {
     testImplementation("junit:junit:${rootProject.extra["junitVersion"]}")
     androidTestImplementation("androidx.test.ext:junit:${rootProject.extra["androidXJunitVersion"]}")
     androidTestImplementation("androidx.test.espresso:espresso-core:${rootProject.extra["espressoVersion"]}")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:${rootProject.extra["composeVersion"]}")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/androidTest/java/com/cgfay/caincamera/FFMediaRecordScreenTest.kt
+++ b/app/src/androidTest/java/com/cgfay/caincamera/FFMediaRecordScreenTest.kt
@@ -1,0 +1,25 @@
+package com.cgfay.caincamera
+
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import com.cgfay.caincamera.activity.FFMediaRecordActivity
+import org.junit.Rule
+import org.junit.Test
+
+class FFMediaRecordScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<FFMediaRecordActivity>()
+
+    @Test
+    fun recordButtonHidesSwitchButton() {
+        composeTestRule.onNodeWithText("Switch").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("record_button")
+            .performTouchInput { down(center); up() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Switch").assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/java/com/cgfay/caincamera/MusicPlayerComposeTest.kt
+++ b/app/src/androidTest/java/com/cgfay/caincamera/MusicPlayerComposeTest.kt
@@ -1,0 +1,37 @@
+package com.cgfay.caincamera
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+import com.cgfay.caincamera.ui.MusicPlayerContent
+
+class MusicPlayerComposeTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun playPauseButtonCallsCallback() {
+        var clicked = false
+        val playingState = mutableStateOf(false)
+        composeTestRule.setContent {
+            MusicPlayerContent(
+                path = "test",
+                isPlaying = playingState.value,
+                progress = 0f,
+                speedProgress = 50f,
+                onPlayPause = {
+                    clicked = true
+                    playingState.value = !playingState.value
+                },
+                onProgressChange = {},
+                onSpeedChange = {}
+            )
+        }
+        composeTestRule.onNodeWithTag("play_pause_button").performClick()
+        composeTestRule.runOnIdle { assertTrue(clicked) }
+    }
+}

--- a/app/src/main/java/com/cgfay/caincamera/ui/FFMediaRecordCompose.kt
+++ b/app/src/main/java/com/cgfay/caincamera/ui/FFMediaRecordCompose.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
@@ -112,6 +113,7 @@ fun FFMediaRecordScreen(onFinish: () -> Unit) {
                 .size(120.dp)
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 40.dp)
+                .testTag("record_button")
         )
         if (uiState.showViews && viewModel.recordVideoSize > 0) {
             Button(

--- a/app/src/main/java/com/cgfay/caincamera/ui/MusicPlayerCompose.kt
+++ b/app/src/main/java/com/cgfay/caincamera/ui/MusicPlayerCompose.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -114,7 +115,10 @@ private fun MusicPlayerContent(
             Text(text = "speed", modifier = Modifier.padding(end = 8.dp))
             Slider(value = speedProgress, onValueChange = onSpeedChange)
         }
-        Button(onClick = onPlayPause, modifier = Modifier.padding(top = 16.dp)) {
+        Button(
+            onClick = onPlayPause,
+            modifier = Modifier.padding(top = 16.dp).testTag("play_pause_button")
+        ) {
             Text(if (isPlaying) "pause" else "play")
         }
         Text(text = path, modifier = Modifier.padding(top = 16.dp))


### PR DESCRIPTION
## Summary
- add Compose UI test dependencies
- tag record and play/pause buttons for tests
- create tests for `FFMediaRecordScreen` and `MusicPlayerCompose`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688469d261a8832cacba1cf56933714d