### PR TITLE
Fix Kotlin 2 Compose compiler plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     kotlin("android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -45,10 +46,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
-    }
-
     repositories {
         flatDir {
             dirs(project(":facedetectlibrary").file("libs"))

--- a/cameralibrary/build.gradle.kts
+++ b/cameralibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -37,9 +38,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeCompilerVersion"] as String
     }
 }
 

--- a/gdxlibrary/build.gradle.kts
+++ b/gdxlibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -50,9 +51,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
     }
     kotlinOptions {
         jvmTarget = "1.8"

--- a/imagelibrary/build.gradle.kts
+++ b/imagelibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -24,10 +25,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
     }
 
     kotlinOptions {

--- a/medialibrary/build.gradle.kts
+++ b/medialibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 val platformVersion = rootProject.extra["minSdkVersion"].toString()
@@ -74,9 +75,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeCompilerVersion"] as String
-    }
 }
 
 dependencies {

--- a/pickerlibrary/build.gradle.kts
+++ b/pickerlibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -32,9 +33,6 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
     }
 }
 

--- a/utilslibrary/build.gradle.kts
+++ b/utilslibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -31,9 +32,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeCompilerVersion"] as String
     }
 }
 

--- a/videolibrary/build.gradle.kts
+++ b/videolibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -23,10 +24,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
     }
 
     kotlinOptions {

--- a/widgetlibrary/build.gradle.kts
+++ b/widgetlibrary/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0"
 }
 
 android {
@@ -28,9 +29,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = rootProject.extra["composeVersion"] as String
-    }
 
     kotlinOptions {
         jvmTarget = "1.8"


### PR DESCRIPTION
## Summary
- apply `org.jetbrains.kotlin.plugin.compose` to all Compose modules
- drop obsolete `composeOptions` blocks

## Testing
- `./gradlew clean build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884dcb32e60832c9a46048c11ead8f7